### PR TITLE
Improvement

### DIFF
--- a/swan-cern/files/swan_config_cern.py
+++ b/swan-cern/files/swan_config_cern.py
@@ -1,7 +1,5 @@
 import os, subprocess
 
-import asyncio
-
 from kubernetes_asyncio.client.models import (
     V1EmptyDirVolumeSource,
     V1EnvVar,
@@ -11,10 +9,8 @@ from kubernetes_asyncio.client.models import (
     V1KeyToPath,
     V1ObjectFieldSelector,
     V1ObjectMeta,
-    V1PodSecurityContext,
     V1Secret,
     V1SecretVolumeSource,
-    V1SELinuxOptions,
     V1Volume,
     V1VolumeMount,
 )
@@ -46,7 +42,6 @@ class SwanPodHookHandlerProd(SwanPodHookHandler):
 
     async def _init_eos_secret(self):
         username = self.spawner.user.name
-        user_uid = self.spawner.user_uid
         eos_secret_name ='eos-tokens-%s' % username
 
         try:

--- a/swan-cern/files/swan_config_cern.py
+++ b/swan-cern/files/swan_config_cern.py
@@ -1,4 +1,5 @@
 import os, subprocess
+import escapism
 
 from kubernetes_asyncio.client.models import (
     V1EmptyDirVolumeSource,
@@ -41,8 +42,11 @@ class SwanPodHookHandlerProd(SwanPodHookHandler):
         return self.pod
 
     async def _init_eos_secret(self):
-        username = self.spawner.user.name
-        eos_secret_name ='eos-tokens-%s' % username
+
+        username = escapism.escape(
+            self.spawner.user.name, safe = self.spawner.safe_chars, escape_char = '-'
+        ).lower()
+        eos_secret_name = 'eos-tokens-%s' % username
 
         try:
             # Retrieve eos token for user

--- a/swan-cern/files/swan_spark_config.py
+++ b/swan-cern/files/swan_spark_config.py
@@ -1,4 +1,4 @@
-import os, subprocess, time, pwd, jwt
+import subprocess
 
 from kubernetes_asyncio.client.models import (
     V1EnvVar,
@@ -16,8 +16,6 @@ from kubernetes_asyncio.client.models import (
 )
 
 from kubernetes_asyncio.client.rest import ApiException
-
-import swanspawner
 
 """
 Class handling KubeSpawner.modify_pod_hook(spawner,pod) call
@@ -116,10 +114,6 @@ class SwanSparkPodHookHandler(SwanPodHookHandlerProd):
         """
         notebook_container = self._get_pod_container('notebook')
         side_container = self._get_pod_container('side-container')
-        username = self.spawner.user.name
-
-        pod_spec_containers = []
-        side_container_volume_mounts = []
 
         if hadoop_secret_name:
             # pod volume to mount generated hadoop tokens and

--- a/swan/files/swan_config.py
+++ b/swan/files/swan_config.py
@@ -26,8 +26,7 @@ class SwanPodHookHandler:
 
         # pod labels
         pod_labels = dict(
-            lcg_release = self.spawner.user_options[self.spawner.lcg_rel_field].split('/')[0],
-            swan_user = self.spawner.user.name
+            lcg_release = self.spawner.user_options[self.spawner.lcg_rel_field].split('/')[0]
         )
 
         # update pod labels

--- a/swan/files/swan_config.py
+++ b/swan/files/swan_config.py
@@ -1,8 +1,7 @@
-import logging, os, subprocess
+import logging
 
 from kubernetes_asyncio.client.models import (
     V1EmptyDirVolumeSource,
-    V1EnvVar,
     V1HostPathVolumeSource,
     V1PersistentVolumeClaimVolumeSource,
     V1Volume,


### PR DESCRIPTION
First question: why do we need a `swan_user` label if JH already provides something similar? 

If we need it, then we need to escape it like kubespawner does (we had issues in a sciencebox deployment).

This commit also removes some leftovers that are not used.